### PR TITLE
Explicitly check for OpenSSL dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
-project(QUIC LANGUAGES C)
+project(QUIC LANGUAGES CXX)
 
 list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 find_package(SpicyPlugin REQUIRED)

--- a/analyzer/CMakeLists.txt
+++ b/analyzer/CMakeLists.txt
@@ -1,5 +1,23 @@
 spicy_add_analyzer(
     NAME QUIC
     PACKAGE_NAME QUIC
-    SOURCES decrypt_crypto.cc QUIC.spicy QUIC.evt
-    SCRIPTS __load__.zeek main.zeek)
+    SOURCES QUIC.spicy QUIC.evt
+    SCRIPTS __load__.zeek main.zeek
+    CXX_LINK ${CMAKE_CURRENT_BINARY_DIR}/libdecrypt_crypto.a)
+
+add_dependencies(QUIC decrypt_crypto)
+
+find_program(SPICY_CONFIG name spicy-config REQUIRED)
+execute_process(
+    COMMAND ${SPICY_CONFIG} --include-dirs
+    OUTPUT_VARIABLE SPICY_INCLUDE_DIRS)
+string(REPLACE " " ";" SPICY_INCLUDE_DIRS ${SPICY_INCLUDE_DIRS})
+
+find_package(OpenSSL REQUIRED)
+add_library(decrypt_crypto STATIC decrypt_crypto.cc)
+set_target_properties(
+    decrypt_crypto PROPERTIES
+    CXX_STANDARD 17
+    POSITION_INDEPENDENT_CODE ON)
+target_include_directories(decrypt_crypto PRIVATE "${OPENSSL_INCLUDE_DIR}" "${SPICY_INCLUDE_DIRS}")
+target_link_libraries(decrypt_crypto ${OpenSSL_LIBRARIES})


### PR DESCRIPTION
Previously this would pick up whatever OpenSSL headers where found in the default search paths and the include directories inherited by Zeek. This e.g., fails on macos with Homebrew.

We now explicitly find OpenSSL. In order to use the existing `spicy_add_analyzer` macro we need to use a `CXX_LINK` against a custom library.