### PR TITLE
Various performance improvements

### DIFF
--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -122,14 +122,6 @@ type FrameType = enum {
 # Helper units
 ##############
 
-# Used to peek into the next byte and determine if it's a long or short packet
-public type InitialByte = unit {
-  initialbyte: bitfield(8) {
-      header_form: 7 &convert=cast<HeaderForm>(cast<uint8>($$));
-      long_packet_type: 4..5 &convert=cast<LongPacketType>(cast<uint8>($$));
-  };
-};
-
 type VariableLengthInteger = unit {
   var bytes_to_parse: uint64;
   var result: uint64;
@@ -342,7 +334,6 @@ type CryptoBuffer = unit() {
 ##############
 type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
   var header_form: HeaderForm;
-  var long_packet_type: LongPacketType;
   var decrypted_data: bytes;
   var full_packet: bytes;
   var start: iterator<stream>;
@@ -367,12 +358,10 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
     self.start = self.input();
   }
 
-  # Peek into the header to check if it's a SHORT or LONG header
-  # and get the LONG packet type.
-  : InitialByte &parse-at=self.input() {
-    self.header_form = $$.initialbyte.header_form;
-    self.long_packet_type = $$.initialbyte.long_packet_type;
-    self.set_input(self.start);
+  # Peek into the first byte and determine the header type.
+  : uint8 {
+    self.header_form = ($$ & 0x80 == 0x80) ? HeaderForm::LONG : HeaderForm::SHORT;
+    self.set_input(self.start);  # rewind
   }
 
   # Depending on the header, parse it and update the src/dest ConnectionID's

--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -208,7 +208,11 @@ public type Frame = unit(header: LongHeaderPacket, from_client: bool, crypto_sin
       crypto_sink.write(self.c.cryptodata, self.c.offset.result);
     }
     FrameType::CONNECTION_CLOSE1 -> : ConnectionClosePayload(header);
+@if SPICY_VERSION >= 10800
+    FrameType::PADDING -> : skip /\x00*/;  # eat the padding
+@else
     FrameType::PADDING -> : /\x00*/;  # eat the padding
+@endif
     FrameType::PING -> : void;
     * -> : void {
       throw "unhandled frame type %s in %s" % (self.frame_type, header.first_byte.packet_type);

--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -11,27 +11,24 @@ public function decrypt_crypto_payload(packet: iterator<stream>, connection_id: 
 ## Context - tracked in one connection
 ##############
 
-# Should we buffer the packet?
-function should_buffer(context: ConnectionIDInfo, is_client: bool): bool {
-  if ( is_client )
-    return ! context.client_initial_processed;
-
-  return context.client_initial_processed
-          && |context.initial_destination_conn_id| > 0
-          && ! context.server_initial_processed;
-}
-
 # Can we decrypt?
-function can_decrypt(long_header: LongHeaderPacket): bool {
+function can_decrypt(long_header: LongHeaderPacket, context: ConnectionIDInfo, is_client: bool): bool {
 
   if ( long_header.first_byte.packet_type != LongPacketType::INITIAL )
     return False;
 
   # decrypt_crypto_payload() has known secrets for version 1, nothing else.
-  if ( long_header.version == 0x00000001 )
-    return True;
+  if ( long_header.version != 0x00000001 )
+    return False;
 
-  return False;
+  if ( is_client )
+    return ! context.client_initial_processed;
+
+  # This is the responder, can only decrypt if we have an initial
+  # destination_id from the client
+  return context.client_initial_processed
+          && |context.initial_destination_conn_id| > 0
+          && ! context.server_initial_processed;
 }
 
 type ConnectionIDInfo = struct {
@@ -401,7 +398,7 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
 @endif
         }
 
-        if ( can_decrypt(self.long_header) && should_buffer(context, from_client) ) {
+        if ( can_decrypt(self.long_header, context, from_client) ) {
 
           # Initialize sink/buffer for accumulating CRYPTO frames.
           #

--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -4,7 +4,13 @@ import spicy;
 import zeek;
 
 # The interface to the C++ code that handles the decryption of the INITIAL packet payload using well-known keys
-public function decrypt_crypto_payload(packet: iterator<stream>, connection_id: bytes, encrypted_offset: uint64, payload_offset: uint64, from_client: bool): bytes &cxxname="decrypt_crypto_payload";
+public function decrypt_crypto_payload(
+  packet: iterator<stream>,
+  connection_id: bytes,
+  encrypted_offset: uint64,
+  payload_offset: uint64,
+  from_client: bool
+): bytes &cxxname="QUIC_decrypt_crypto_payload";
 
 
 ##############

--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -4,7 +4,7 @@ import spicy;
 import zeek;
 
 # The interface to the C++ code that handles the decryption of the INITIAL packet payload using well-known keys
-public function decrypt_crypto_payload(entire_packet: bytes, connection_id: bytes, encrypted_offset: uint64, payload_offset: uint64, from_client: bool): bytes &cxxname="decrypt_crypto_payload";
+public function decrypt_crypto_payload(packet: iterator<stream>, connection_id: bytes, encrypted_offset: uint64, payload_offset: uint64, from_client: bool): bytes &cxxname="decrypt_crypto_payload";
 
 
 ##############
@@ -160,17 +160,6 @@ type VariableLengthInteger = unit {
 # Long packets
 # Generic units
 ##############
-
-# Used to capture all data form the entire frame. May be inefficient, but works for now.
-# This is passed to the decryption function, as this function needs both the header and the payload
-# Performs a backtrack() at the end
-type AllData = unit {
-  var data: bytes;
-
-  : bytes &eod {
-    self.data = $$;
-  }
-};
 
 public type LongHeaderPacket = unit {
   var encrypted_offset: uint64;
@@ -385,17 +374,6 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
     self.set_input(self.start);
   }
 
-  # Capture all the packet bytes if we're still have a chance of decrypting the INITIAL PACKETS
-  #
-  # TODO: Make decrypt_crypto_payload() use the iterator<stream> self.start instead of copying
-  #       the data here.
-  fpack: AllData &parse-at=self.input() if ( self.header_form == HeaderForm::LONG &&
-                           self.long_packet_type == LongPacketType::INITIAL &&
-                           should_buffer(context, from_client) ) {
-
-    self.set_input(self.start);
-  }
-
   # Depending on the header, parse it and update the src/dest ConnectionID's
   switch ( self.header_form ) {
     HeaderForm::SHORT -> short_header: ShortHeader(context.client_cid_len);
@@ -434,7 +412,8 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
             # This means that here, we can try to decrypt the initial packet!
             # All data is accessible via the `long_header` unit
 
-            self.decrypted_data = decrypt_crypto_payload(self.fpack.data,
+            self.decrypted_data = decrypt_crypto_payload(
+                                   self.start,
                                    self.long_header.dest_conn_id,
                                    self.long_header.encrypted_offset,
                                    self.long_header.payload_length,
@@ -451,7 +430,8 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
 
             # Assuming that the client set up the connection, this can be considered the first
             # received Initial from the client. So disable change of ConnectionID's afterwards
-            self.decrypted_data = decrypt_crypto_payload(self.fpack.data,
+            self.decrypted_data = decrypt_crypto_payload(
+                                   self.start,
                                    context.initial_destination_conn_id,
                                    self.long_header.encrypted_offset,
                                    self.long_header.payload_length,

--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -209,11 +209,6 @@ public type Frame = unit(header: LongHeaderPacket, from_client: bool, crypto_sin
   };
 };
 
-# TODO: investigate whether we can do something useful with this
-public type EncryptedLongPacketPayload = unit {
-  payload: bytes &eod;
-};
-
 type CRYPTOPayload = unit(from_client: bool) {
   offset: VariableLengthInteger;
   length: VariableLengthInteger;
@@ -312,7 +307,20 @@ public type ShortHeader = unit(dest_conn_id_length: uint8) {
 
 # TODO: investigate whether we can parse something useful out of this
 public type ShortPacketPayload = unit {
+@if SPICY_VERSION >= 10800
+  payload: skip bytes &eod;
+@else
   payload: bytes &eod;
+@endif
+};
+
+# TODO: investigate whether we can do something useful with this
+public type EncryptedLongPacketPayload = unit {
+@if SPICY_VERSION >= 10800
+  payload: skip bytes &eod;
+@else
+  payload: bytes &eod;
+@endif
 };
 
 # Buffer all crypto messages (which might be fragmented and unordered)

--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -265,19 +265,31 @@ type InitialPacket = unit(header: LongHeaderPacket) {
   # includes the packet number field, but we
   # do not know its length yet. We need the
   # payload for sampling, however.
+@if SPICY_VERSION >= 10800
+  payload: skip bytes &size=self.length.result;
+@else
   payload: bytes &size=self.length.result;
+@endif
 };
 
 type ZeroRTTPacket = unit(header: LongHeaderPacket) {
   var header: LongHeaderPacket = header;
   length: VariableLengthInteger;
+@if SPICY_VERSION >= 10800
+  payload: skip bytes &size=self.length.result;
+@else
   payload: bytes &size=self.length.result;
+@endif
 };
 
 type HandshakePacket = unit(header: LongHeaderPacket) {
   var header: LongHeaderPacket = header;
   length: VariableLengthInteger;
+@if SPICY_VERSION >= 10800
+  payload: skip bytes &size=self.length.result;
+@else
   payload: bytes &size=self.length.result;
+@endif
 };
 
 

--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -131,9 +131,6 @@ public type InitialByte = unit {
       header_form: 7 &convert=cast<HeaderForm>(cast<uint8>($$));
       long_packet_type: 4..5 &convert=cast<LongPacketType>(cast<uint8>($$));
   };
-  on %done {
-    self.backtrack();
-  }
 };
 
 type VariableLengthInteger = unit {
@@ -172,10 +169,6 @@ type AllData = unit {
 
   : bytes &eod {
     self.data = $$;
-  }
-
-  on %done {
-    self.backtrack();
   }
 };
 
@@ -362,6 +355,7 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
   var long_packet_type: LongPacketType;
   var decrypted_data: bytes;
   var full_packet: bytes;
+  var start: iterator<stream>;
 
   sink crypto_sink;
   var crypto_buffer: CryptoBuffer&;
@@ -379,19 +373,28 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
       context.did_ssl_begin = True;
       }
 @endif
+
+    self.start = self.input();
   }
 
   # Peek into the header to check if it's a SHORT or LONG header
   # and get the LONG packet type.
-  : InitialByte &try {
+  : InitialByte &parse-at=self.input() {
     self.header_form = $$.initialbyte.header_form;
     self.long_packet_type = $$.initialbyte.long_packet_type;
+    self.set_input(self.start);
   }
 
   # Capture all the packet bytes if we're still have a chance of decrypting the INITIAL PACKETS
-  fpack: AllData &try if ( self.header_form == HeaderForm::LONG &&
+  #
+  # TODO: Make decrypt_crypto_payload() use the iterator<stream> self.start instead of copying
+  #       the data here.
+  fpack: AllData &parse-at=self.input() if ( self.header_form == HeaderForm::LONG &&
                            self.long_packet_type == LongPacketType::INITIAL &&
-                           should_buffer(context, from_client) );
+                           should_buffer(context, from_client) ) {
+
+    self.set_input(self.start);
+  }
 
   # Depending on the header, parse it and update the src/dest ConnectionID's
   switch ( self.header_form ) {

--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -5,7 +5,7 @@ import zeek;
 
 # The interface to the C++ code that handles the decryption of the INITIAL packet payload using well-known keys
 public function decrypt_crypto_payload(
-  packet: iterator<stream>,
+  all_data: bytes,
   connection_id: bytes,
   encrypted_offset: uint64,
   payload_offset: uint64,
@@ -359,7 +359,6 @@ type CryptoBuffer = unit() {
 # A UDP datagram contains one or more QUIC packets.
 ##############
 type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
-  var header_form: HeaderForm;
   var decrypted_data: bytes;
   var full_packet: bytes;
   var start: iterator<stream>;
@@ -374,24 +373,29 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
       context.ssl_handle = zeek::protocol_handle_get_or_create("SSL");
     }
 @else
-    if ( ! context.did_ssl_begin )
-      {
+    if ( ! context.did_ssl_begin ) {
       zeek::protocol_begin("SSL");
       context.did_ssl_begin = True;
-      }
+    }
 @endif
 
     self.start = self.input();
   }
 
   # Peek into the first byte and determine the header type.
-  : uint8 {
-    self.header_form = ($$ & 0x80 == 0x80) ? HeaderForm::LONG : HeaderForm::SHORT;
+  first_byte: bitfield(8) {
+    header_form: 7 &convert=HeaderForm($$);
+  };
+
+  # TODO: Consider bitfield based look-ahead-parsing in the switch below
+  #       to avoid this rewinding here. It's a hack.
+  : void {
     self.set_input(self.start);  # rewind
   }
 
+
   # Depending on the header, parse it and update the src/dest ConnectionID's
-  switch ( self.header_form ) {
+  switch ( self.first_byte.header_form ) {
     HeaderForm::SHORT -> short_header: ShortHeader(context.client_cid_len);
     HeaderForm::LONG -> long_header: LongHeaderPacket {
         # For now, only allow a change of src/dest ConnectionID's for INITIAL packets.
@@ -412,77 +416,77 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
           context.did_ssl_begin = False;
 @endif
         }
-
-        if ( can_decrypt(self.long_header, context, from_client) ) {
-
-          # Initialize sink/buffer for accumulating CRYPTO frames.
-          #
-          # TODO: Attach this to the context instead of unit.
-          self.crypto_buffer = new CryptoBuffer();
-          self.crypto_sink.connect(self.crypto_buffer);
-
-          if ( from_client ) {
-            context.server_cid_len = self.long_header.dest_conn_id_len;
-            context.client_cid_len = self.long_header.src_conn_id_len;
-
-            # This means that here, we can try to decrypt the initial packet!
-            # All data is accessible via the `long_header` unit
-
-            self.decrypted_data = decrypt_crypto_payload(
-                                   self.start,
-                                   self.long_header.dest_conn_id,
-                                   self.long_header.encrypted_offset,
-                                   self.long_header.payload_length,
-                                   from_client);
-
-            # Set this to be the seed for the decryption
-            if ( |context.initial_destination_conn_id| == 0 ) {
-              context.initial_destination_conn_id = self.long_header.dest_conn_id;
-            }
-
-          } else {
-            context.server_cid_len = self.long_header.src_conn_id_len;
-            context.client_cid_len = self.long_header.dest_conn_id_len;
-
-            # Assuming that the client set up the connection, this can be considered the first
-            # received Initial from the client. So disable change of ConnectionID's afterwards
-            self.decrypted_data = decrypt_crypto_payload(
-                                   self.start,
-                                   context.initial_destination_conn_id,
-                                   self.long_header.encrypted_offset,
-                                   self.long_header.payload_length,
-                                   from_client);
-          }
-
-          # We attempted decryption, but it failed. Just reject the
-          # input and assume Zeek will disable the analyzer for this
-          # connection.
-          if ( |self.decrypted_data| == 0 )
-            throw "decryption failed";
-        }
-
-        # If it's a reply from the server and it's not a REPLY, we assume the keys are restablished and decryption is no longer possible
-        # TODO: verify if this is actually correct per RFC
-        if (self.long_header.first_byte.packet_type != LongPacketType::RETRY && ! from_client) {
-          context.server_initial_processed = True;
-          context.client_initial_processed = True;
-        }
-    }
+     }
   };
+
+  # Slurp in the whole packet if we determined we have a chance to decrypt.
+  all_data: bytes &parse-at=self.start &eod if ( self?.long_header && can_decrypt(self.long_header, context, from_client) ) {
+    self.crypto_buffer = new CryptoBuffer();
+    self.crypto_sink.connect(self.crypto_buffer);
+
+    if ( from_client ) {
+      context.server_cid_len = self.long_header.dest_conn_id_len;
+      context.client_cid_len = self.long_header.src_conn_id_len;
+
+      # This means that here, we can try to decrypt the initial packet!
+      # All data is accessible via the `long_header` unit
+      self.decrypted_data = decrypt_crypto_payload(
+        self.all_data,
+        self.long_header.dest_conn_id,
+        self.long_header.encrypted_offset,
+        self.long_header.payload_length,
+        from_client
+      );
+
+      # Set this to be the seed for the decryption
+      if ( |context.initial_destination_conn_id| == 0 ) {
+        context.initial_destination_conn_id = self.long_header.dest_conn_id;
+      }
+
+    } else {
+      context.server_cid_len = self.long_header.src_conn_id_len;
+      context.client_cid_len = self.long_header.dest_conn_id_len;
+
+      # Assuming that the client set up the connection, this can be considered the first
+      # received Initial from the client. So disable change of ConnectionID's afterwards
+      self.decrypted_data = decrypt_crypto_payload(
+        self.all_data,
+        context.initial_destination_conn_id,
+        self.long_header.encrypted_offset,
+        self.long_header.payload_length,
+        from_client
+      );
+    }
+
+    # We attempted decryption, but it failed. Just reject the
+    # input and assume Zeek will disable the analyzer for this
+    # connection.
+    if ( |self.decrypted_data| == 0 )
+      throw "decryption failed";
+
+    # If this was a reply from the server and it's not a RETRY, we assume the keys
+    # are restablished and decryption is no longer possible
+    #
+    # TODO: verify if this is actually correct per RFC
+    if ( self.long_header.first_byte.packet_type != LongPacketType::RETRY && ! from_client ) {
+      context.server_initial_processed = True;
+      context.client_initial_processed = True;
+    }
+  }
 
   # Depending on the type of header and whether we were able to decrypt
   # some of it, parse the remaining payload.
-  : ShortPacketPayload if (self.header_form == HeaderForm::SHORT);
-  : EncryptedLongPacketPayload if (self.header_form == HeaderForm::LONG && |self.decrypted_data| == 0);
+  : ShortPacketPayload if (self.first_byte.header_form == HeaderForm::SHORT);
+  : EncryptedLongPacketPayload if (self.first_byte.header_form == HeaderForm::LONG && |self.decrypted_data| == 0);
 
   # If this was packet with a long header and decrypted data exists, attempt
   # to parse the plain QUIC frames from it.
-  frames: Frame(self.long_header, from_client, self.crypto_sink)[] &parse-from=self.decrypted_data if (self.header_form == HeaderForm::LONG && |self.decrypted_data| > 0);
+  frames: Frame(self.long_header, from_client, self.crypto_sink)[] &parse-from=self.decrypted_data if (self.first_byte.header_form == HeaderForm::LONG && |self.decrypted_data| > 0);
 
   # Once the Packet is fully parsed, pass the accumulated CRYPTO frames
   # to the SSL analyzer as handshake data.
   on %done {
-    # print "packet done", zeek::is_orig(), self.header_form, |self.decrypted_data|;
+    # print "packet done", zeek::is_orig(), self.first_byte.header_form, |self.decrypted_data|;
 
     if ( self.crypto_buffer != Null && |self.crypto_buffer.buffered| > 0 ) {
       local handshake_data = self.crypto_buffer.buffered;

--- a/analyzer/decrypt_crypto.cc
+++ b/analyzer/decrypt_crypto.cc
@@ -273,7 +273,7 @@ hilti::rt::Bytes decrypt_crypto_payload(const hilti::rt::stream::SafeConstIterat
 
 	// Fill in the entire packet bytes
 	std::vector<uint8_t> e_pkt;
-	hilti::rt::stream::SafeConstIterator it = packet_stream;
+	hilti::rt::stream::detail::UnsafeConstIterator it{packet_stream};
 	while ( ! it.isEnd() )
 		e_pkt.push_back(*(it++));
 

--- a/analyzer/decrypt_crypto.cc
+++ b/analyzer/decrypt_crypto.cc
@@ -23,6 +23,9 @@ refactors as C++ development is not our main profession.
 // Import HILTI
 #include <hilti/rt/libhilti.h>
 
+namespace
+	{
+
 // Struct to store decryption info for this specific connection
 struct DecryptionInformation
 	{
@@ -252,16 +255,19 @@ hilti::rt::Bytes decrypt(const std::vector<uint8_t>& client_key,
 	return hilti::rt::Bytes(decrypt_buffer.data(), decrypt_buffer.data() + out);
 	}
 
+	}
+
 /*
 Function that is called from Spicy. It's a wrapper around `process_data`;
 it stores all the passed data in a global struct and then calls `process_data`,
 which will eventually return the decrypted data and pass it back to Spicy.
 */
-hilti::rt::Bytes decrypt_crypto_payload(const hilti::rt::stream::SafeConstIterator& packet_stream,
-                                        const hilti::rt::Bytes& connection_id,
-                                        const hilti::rt::integer::safe<uint64_t>& encrypted_offset,
-                                        const hilti::rt::integer::safe<uint64_t>& payload_length,
-                                        const hilti::rt::Bool& from_client)
+hilti::rt::Bytes
+QUIC_decrypt_crypto_payload(const hilti::rt::stream::SafeConstIterator& packet_stream,
+                            const hilti::rt::Bytes& connection_id,
+                            const hilti::rt::integer::safe<uint64_t>& encrypted_offset,
+                            const hilti::rt::integer::safe<uint64_t>& payload_length,
+                            const hilti::rt::Bool& from_client)
 	{
 
 	if ( payload_length < 20 )

--- a/analyzer/decrypt_crypto.cc
+++ b/analyzer/decrypt_crypto.cc
@@ -184,7 +184,7 @@ DecryptionInformation remove_header_protection(const std::vector<uint8_t>& clien
 Calculate the nonce for the AEAD by XOR'ing the CLIENT_IV and the
 decoded packet number, and returns the nonce
 */
-std::vector<uint8_t> calculate_nonce(std::vector<uint8_t> client_iv, uint64_t packet_number)
+std::vector<uint8_t> calculate_nonce(const std::vector<uint8_t>& client_iv, uint64_t packet_number)
 	{
 	std::vector<uint8_t> nonce = client_iv;
 

--- a/analyzer/decrypt_crypto.cc
+++ b/analyzer/decrypt_crypto.cc
@@ -95,8 +95,8 @@ std::vector<uint8_t> hkdf_extract(const hilti::rt::Bytes& connection_id)
 HKDF-Expand-Label as described in https://www.rfc-editor.org/rfc/rfc8446.html#section-7.1
 that uses the global constant labels such as 'quic hp'.
 */
-std::vector<uint8_t> hkdf_expand(size_t out_len, std::vector<uint8_t> key,
-                                 std::vector<uint8_t> info)
+std::vector<uint8_t> hkdf_expand(size_t out_len, const std::vector<uint8_t>& key,
+                                 const std::vector<uint8_t>& info)
 	{
 	std::vector<uint8_t> out_temp(out_len);
 	const EVP_MD* digest = EVP_sha256();

--- a/analyzer/decrypt_crypto.cc
+++ b/analyzer/decrypt_crypto.cc
@@ -8,6 +8,7 @@ refactors as C++ development is not our main profession.
 */
 
 // Default imports
+#include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -133,7 +134,7 @@ DecryptionInformation remove_header_protection(const std::vector<uint8_t>& clien
 
 	const uint8_t* sample = &encrypted_packet[encrypted_offset + MAXIMUM_PACKET_NUMBER_LENGTH];
 
-	std::vector<uint8_t> mask(AEAD_SAMPLE_LENGTH);
+	std::array<uint8_t, AEAD_SAMPLE_LENGTH> mask;
 	EVP_CipherUpdate(ctx, mask.data(), &outlen, sample, AEAD_SAMPLE_LENGTH);
 	EVP_CIPHER_CTX_free(ctx);
 
@@ -216,7 +217,7 @@ hilti::rt::Bytes decrypt(const std::vector<uint8_t>& client_key,
 	                      decryptInfo.packet_number_length - AEAD_TAG_LENGTH];
 	int tag_to_check_length = AEAD_TAG_LENGTH;
 
-	unsigned char decrypt_buffer[MAXIMUM_PACKET_LENGTH];
+	std::array<uint8_t, MAXIMUM_PACKET_LENGTH> decrypt_buffer;
 
 	// Setup context
 	auto cipher = EVP_aes_128_gcm();
@@ -241,14 +242,14 @@ hilti::rt::Bytes decrypt(const std::vector<uint8_t>& client_key,
 
 	// Set the actual data to decrypt data into the decrypt_buffer. The amount of
 	// byte decrypted is stored into `out`
-	EVP_CipherUpdate(ctx, decrypt_buffer, &out, encrypted_payload, encrypted_payload_size);
+	EVP_CipherUpdate(ctx, decrypt_buffer.data(), &out, encrypted_payload, encrypted_payload_size);
 
 	// Validate whether the decryption was successful or not
 	EVP_CipherFinal_ex(ctx, NULL, &out2);
 	EVP_CIPHER_CTX_free(ctx);
 
 	// Copy the decrypted data from the decrypted buffer into a Bytes instance.
-	return hilti::rt::Bytes(decrypt_buffer, decrypt_buffer + out);
+	return hilti::rt::Bytes(decrypt_buffer.data(), decrypt_buffer.data() + out);
 	}
 
 /*


### PR DESCRIPTION
Rough summary:

* &try/backtrack() removal
* remove one packet copy on the analyzer level and pass an iterator into the decryption function (still one copy in the decryption code)
* pass std::vector as const ref when possible
* `skip` optimization for padding and `bytes` fields that are otherwise not used.

On a pcap created with Python's aioquic package containing roughly 12k quic connections, this PR reduces runtime from ~18.5seconds to ~12seconds. By far the largest impact had removal of the previous `&try / backtrack()` approach - see also  zeek/spicy#1565.