### PR TITLE
README/ci/evt: Fixes after merging into Zeek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
         image:
           - zeek-6.0
           - zeek-5.2
-          - zeek-dev
     steps:
     - uses: actions/checkout@v2
     - run: docker build -t ${{ matrix.image }}-quic -f docker/${{ matrix.image }}.Dockerfile .

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,6 @@ jobs:
         image:
           - zeek-6.0
           - zeek-5.2
-          - zeek-dev
     steps:
     - uses: actions/checkout@v2
     - run: docker build -t ${{ matrix.image }}-quic -f docker/${{ matrix.image }}.Dockerfile .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Spicy analyzer for the QUIC protocol
 
+> **Note**
+>
+> Zeek 6.1 and later versions include the QUIC analyzer.
+> You no longer need this package when using those Zeek versions.
+
 A QUIC protocol analyzer for Zeek, based on Spicy. This analyzer tries to be
 compatible with [QUIC IETF version 1](https://datatracker.ietf.org/doc/html/rfc9000)
 Current focus is on extraction of ClientHello and ServerHello messages from

--- a/analyzer/QUIC.evt
+++ b/analyzer/QUIC.evt
@@ -1,8 +1,10 @@
 # Copyright (c) 2023, NCC Group / Fox-IT. See COPYING for details.
 # Copyright (c) 2023 by the Zeek Project. See COPYING for details.
 
+@if ZEEK_VERSION >= 60100
 %doc-id = Zeek::QUIC;
 %doc-description = "QUIC analyzer";
+@endif
 
 protocol analyzer QUIC over UDP:
     parse originator with QUIC::RequestFrame,


### PR DESCRIPTION
I had done the doc-id/doc-description change directly on main, but it wasn't complete and there's a bit more to do.