### PR TITLE
Fix not decrypting server's INITIAL packets

### DIFF
--- a/analyzer/QUIC.spicy
+++ b/analyzer/QUIC.spicy
@@ -528,7 +528,8 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
         from_client
       );
 
-      # Set this to be the seed for the decryption
+      # Assuming that the client set up the connection, this can be considered the first
+      # received Initial from the client. So disable change of ConnectionID's afterwards
       if ( |context.initial_destination_conn_id| == 0 ) {
         context.initial_destination_conn_id = self.long_header.dest_conn_id;
       }
@@ -537,8 +538,6 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
       context.server_cid_len = self.long_header.src_conn_id_len;
       context.client_cid_len = self.long_header.dest_conn_id_len;
 
-      # Assuming that the client set up the connection, this can be considered the first
-      # received Initial from the client. So disable change of ConnectionID's afterwards
       self.decrypted_data = decrypt_crypto_payload(
         self.long_header.version,
         self.all_data,
@@ -554,15 +553,6 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
     # connection.
     if ( |self.decrypted_data| == 0 )
       throw "decryption failed";
-
-    # If this was a reply from the server and it's not a RETRY, we assume the keys
-    # are restablished and decryption is no longer possible
-    #
-    # TODO: verify if this is actually correct per RFC
-    if ( ! self.long_header.is_retry && ! from_client ) {
-      context.server_initial_processed = True;
-      context.client_initial_processed = True;
-    }
   }
 
   # Depending on the type of header and whether we were able to decrypt
@@ -594,8 +584,8 @@ type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
 @endif
       );
 
-      # Stop decryption attempts after processing the very first
-      # INITIAL packet.
+      # Stop decryption attempts after processing the very first INITIAL
+      # INITIAL packet for which we forwarded data to the SSL analyzer.
       if ( from_client )
         context.client_initial_processed = True;
       else

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -27,10 +27,13 @@ export {
 		## by client and server.
 		client_initial_dcid: string  &log &optional;
 
+		## Client's Source Connection ID from the first INITIAL packet.
+		client_scid:         string  &log &optional;
+
 		## Server chosen Connection ID usually from server's first
 		## INITIAL packet. This is to be used by the client in
 		## subsequent packets.
-		server_scid:        string  &log &optional;
+		server_scid:         string  &log &optional;
 
 		## Server name extracted from SNI extension in ClientHello
 		## packet if available.
@@ -122,7 +125,9 @@ function set_session(c: connection, is_orig: bool, version: count, dcid: string,
 	if ( is_orig && |dcid| > 0 && ! c$quic?$client_initial_dcid )
 		c$quic$client_initial_dcid = bytestring_to_hexstr(dcid);
 
-	if ( ! is_orig && |scid| > 0 )
+	if ( is_orig )
+		c$quic$client_scid = bytestring_to_hexstr(scid);
+	else
 		c$quic$server_scid = bytestring_to_hexstr(scid);
 	}
 

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -105,7 +105,7 @@ function log_record(quic: Info)
 	quic$logged = T;
 	}
 
-function set_conn(c: connection, is_orig: bool, version: count, dcid: string, scid: string)
+function set_session(c: connection, is_orig: bool, version: count, dcid: string, scid: string)
 	{
 	if ( ! c?$quic )
 		{
@@ -128,19 +128,19 @@ function set_conn(c: connection, is_orig: bool, version: count, dcid: string, sc
 
 event QUIC::initial_packet(c: connection, is_orig: bool, version: count, dcid: string, scid: string)
 	{
-	set_conn(c, is_orig, version, dcid, scid);
+	set_session(c, is_orig, version, dcid, scid);
 	add_to_history(c, is_orig, "INIT");
 	}
 
 event QUIC::handshake_packet(c: connection, is_orig: bool, version: count, dcid: string, scid: string)
 	{
-	set_conn(c, is_orig, version, dcid, scid);
+	set_session(c, is_orig, version, dcid, scid);
 	add_to_history(c, is_orig, "HANDSHAKE");
 	}
 
 event QUIC::zero_rtt_packet(c: connection, is_orig: bool, version: count, dcid: string, scid: string)
 	{
-	set_conn(c, is_orig, version, dcid, scid);
+	set_session(c, is_orig, version, dcid, scid);
 	add_to_history(c, is_orig, "ZeroRTT");
 	}
 
@@ -148,7 +148,7 @@ event QUIC::zero_rtt_packet(c: connection, is_orig: bool, version: count, dcid: 
 event QUIC::retry_packet(c: connection, is_orig: bool, version: count, dcid: string, scid: string, retry_token: string, integrity_tag: string)
 	{
 	if ( ! c?$quic )
-		set_conn(c, is_orig, version, dcid, scid);
+		set_session(c, is_orig, version, dcid, scid);
 
 	add_to_history(c, is_orig, "RETRY");
 
@@ -161,7 +161,7 @@ event QUIC::retry_packet(c: connection, is_orig: bool, version: count, dcid: str
 event QUIC::unhandled_version(c: connection, is_orig: bool, version: count, dcid: string, scid: string)
 	{
 	if ( ! c?$quic )
-		set_conn(c, is_orig, version, dcid, scid);
+		set_session(c, is_orig, version, dcid, scid);
 
 	add_to_history(c, is_orig, "UNHANDLED_VERSION");
 

--- a/testing/Baseline/tests.chromium/quic.log
+++ b/testing/Baseline/tests.chromium/quic.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	82.239.54.117	53727	110.213.53.115	443	1	95412c47018cdfe8	d5412c47018cdfe8	api.cirrus-ci.com	h3	ISisH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	82.239.54.117	53727	110.213.53.115	443	1	95412c47018cdfe8	(empty)	d5412c47018cdfe8	api.cirrus-ci.com	h3	ISisH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.curl-http3/quic.log
+++ b/testing/Baseline/tests.curl-http3/quic.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	172.17.0.2	34347	64.233.166.94	443	1	815d62c70884f4b51e8ccadd5beed372	c15d62c70884f4b5	www.google.de	h3	ISishIhHhhH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	172.17.0.2	34347	64.233.166.94	443	1	815d62c70884f4b51e8ccadd5beed372	e5ec6b26584229be98a164349ae910351c40d10b	c15d62c70884f4b5	www.google.de	h3	ISishIhHhhH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.firefox/quic.log
+++ b/testing/Baseline/tests.firefox/quic.log
@@ -7,5 +7,5 @@
 #open XXXX-XX-XX-XX-XX-XX
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
 #types	time	string	addr	port	addr	port	string	string	string	string	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	82.239.54.117	44174	250.58.23.113	443	1	c5a5015ae8f479784a	01275b138ee6aca8a6276b132ae6b3547cf7773f	blog.cloudflare.com	h3	ISiihIhhhHHhHH
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	82.239.54.117	44174	250.58.23.113	443	1	c5a5015ae8f479784a	01275b138ee6aca8a6276b132ae6b3547cf7773f	blog.cloudflare.com	h3	ISiishIhhhHHhHH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.firefox/quic.log
+++ b/testing/Baseline/tests.firefox/quic.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	82.239.54.117	44174	250.58.23.113	443	1	c5a5015ae8f479784a	01275b138ee6aca8a6276b132ae6b3547cf7773f	blog.cloudflare.com	h3	ISiishIhhhHHhHH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	82.239.54.117	44174	250.58.23.113	443	1	c5a5015ae8f479784a	34696c	01275b138ee6aca8a6276b132ae6b3547cf7773f	blog.cloudflare.com	h3	ISiishIhhhHHhHH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.firefox/ssl.log
+++ b/testing/Baseline/tests.firefox/ssl.log
@@ -7,5 +7,5 @@
 #open XXXX-XX-XX-XX-XX-XX
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	cipher	curve	server_name	resumed	last_alert	next_protocol	established	ssl_history	cert_chain_fps	client_cert_chain_fps	sni_matches_cert
 #types	time	string	addr	port	addr	port	string	string	string	string	bool	string	string	bool	string	vector[string]	vector[string]	bool
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	82.239.54.117	44174	250.58.23.113	443	-	-	-	blog.cloudflare.com	F	-	-	F	C	-	-	-
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	82.239.54.117	44174	250.58.23.113	443	TLSv13	TLS_AES_128_GCM_SHA256	x25519	blog.cloudflare.com	F	-	-	F	Cs	-	-	-
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.interop.quic-go_quic-go.handshake/quic.log
+++ b/testing/Baseline/tests.interop.quic-go_quic-go.handshake/quic.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-1.000000	C4J4Th3PJpwUYZZ6gc	193.167.0.100	40084	193.167.100.100	443	1	a771f6161a4072c0bf10	5911deff	server4:443	hq-interop	ISishIH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+1.000000	C4J4Th3PJpwUYZZ6gc	193.167.0.100	40084	193.167.100.100	443	1	a771f6161a4072c0bf10	(empty)	5911deff	server4:443	hq-interop	ISishIH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.interop.quic-go_quic-go.retry/quic.log
+++ b/testing/Baseline/tests.interop.quic-go_quic-go.retry/quic.log
@@ -5,8 +5,8 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-1.000000	C4J4Th3PJpwUYZZ6gc	193.167.0.100	42834	193.167.100.100	443	1	4a8294bf9201d6cf	-	server4:443	hq-interop	ISr
-1.000000	C4J4Th3PJpwUYZZ6gc	193.167.0.100	42834	193.167.100.100	443	1	1b036a11	fc674735	server4:443	hq-interop	ISishIH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+1.000000	C4J4Th3PJpwUYZZ6gc	193.167.0.100	42834	193.167.100.100	443	1	4a8294bf9201d6cf	(empty)	-	server4:443	hq-interop	ISr
+1.000000	C4J4Th3PJpwUYZZ6gc	193.167.0.100	42834	193.167.100.100	443	1	1b036a11	(empty)	fc674735	server4:443	hq-interop	ISishIH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.interop.quic-go_quic-go.zerortt/quic.log
+++ b/testing/Baseline/tests.interop.quic-go_quic-go.zerortt/quic.log
@@ -5,8 +5,8 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-1.000000	CtPZjS20MLrsMUOJi2	193.167.0.100	49394	193.167.100.100	443	1	15ae5e5e4962163f410b5529fc125bbc	e483a751	server4:443	hq-interop	ISZisZZZZZ
-1.000000	C4J4Th3PJpwUYZZ6gc	193.167.0.100	60492	193.167.100.100	443	1	b7c7841c64883e3261d840	8d2041ac	server4:443	hq-interop	ISishIH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+1.000000	CtPZjS20MLrsMUOJi2	193.167.0.100	49394	193.167.100.100	443	1	15ae5e5e4962163f410b5529fc125bbc	(empty)	e483a751	server4:443	hq-interop	ISZisZZZZZZZZZZZZZZZZZZZZZZZZZZZIH
+1.000000	C4J4Th3PJpwUYZZ6gc	193.167.0.100	60492	193.167.100.100	443	1	b7c7841c64883e3261d840	(empty)	8d2041ac	server4:443	hq-interop	ISishIH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.quic-log/quic.log
+++ b/testing/Baseline/tests.quic-log/quic.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	669b:cb7a:de99:6a13:4a9b:46ef:3bed:cb6c	57538	6699:ded3:da8c:be73:5a99:ca73:5a99:cadb	443	1	5a37463b0eb7cc5d	da37463b0eb7cc5d	www.google.de	h3	ISishIhHhhHH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	669b:cb7a:de99:6a13:4a9b:46ef:3bed:cb6c	57538	6699:ded3:da8c:be73:5a99:ca73:5a99:cadb	443	1	5a37463b0eb7cc5d	(empty)	da37463b0eb7cc5d	www.google.de	h3	ISishIhHhhHH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.quicdoq/quic.log
+++ b/testing/Baseline/tests.quicdoq/quic.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	46907	127.0.0.1	853	1	fda05288ab9ff546	a31f4933d8727231	-	doq	ISishH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	46907	127.0.0.1	853	1	fda05288ab9ff546	0fb934775f247b8e	a31f4933d8727231	-	doq	ISishH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.quicv2-echo-443/quic.log
+++ b/testing/Baseline/tests.quicv2-echo-443/quic.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	49320	127.0.0.1	443	quicv2	fa603212c8688817af3d3238735bc7	b168b5cc	localhost	quic-echo-example	ISIIisIH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	49320	127.0.0.1	443	quicv2	fa603212c8688817af3d3238735bc7	(empty)	b168b5cc	localhost	quic-echo-example	ISIIisIH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.quicv2-http3-443/quic.log
+++ b/testing/Baseline/tests.quicv2-http3-443/quic.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	50841	127.0.0.1	443	quicv2	bdf0c5b27927cc667e58d95b	cdc8b6e6	-	h3	ISishIHH
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	50841	127.0.0.1	443	quicv2	bdf0c5b27927cc667e58d95b	71b8f3f4	cdc8b6e6	-	h3	ISishIHH
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/Baseline/tests.vector-max-size-crash/quic.log
+++ b/testing/Baseline/tests.vector-max-size-crash/quic.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	quic
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	server_scid	server_name	client_protocol	history
-#types	time	string	addr	port	addr	port	string	string	string	string	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	1.2.3.4	45492	7.7.7.7	443	unknown-10010000	00	-	-	-	U
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	client_initial_dcid	client_scid	server_scid	server_name	client_protocol	history
+#types	time	string	addr	port	addr	port	string	string	string	string	string	string	string
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	1.2.3.4	45492	7.7.7.7	443	unknown-10010000	00	(empty)	-	-	-	U
 #close XXXX-XX-XX-XX-XX-XX


### PR DESCRIPTION
* Don't stop processing INITIAL packets after the first one, it might have just contained ACK frames.
* Rename set_conn() to set_session()
* Also log client_scid

See commits for a bit more information. I wanted to use quic.log as an example and these all came up :-)